### PR TITLE
Dockerfile tweaks for singularity support and download url updates

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ RUN cd /opt \
   && cd /opt/bin \
   && wget -qO- http://get.nextflow.io | bash \
   && chmod 755 /opt/bin/nextflow \
+  && /opt/bin/nextflow \
   && wget https://github.com/refresh-bio/KMC/releases/download/v3.0.0/KMC3.linux.tar.gz \
   && tar -zxvf KMC3.linux.tar.gz \
   && rm -f KMC3.linux.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN cd /opt \
   && git clone https://github.com/droe-nmdp/kpi.git \
   && mkdir -p /opt/kpi/raw /opt/bin \
   && cd /opt/bin \
-  && wget http://www.nextflow.io/releases/v19.01.0/nextflow?a=install -o /opt/bin/nextflow \
+  && wget -qO- http://get.nextflow.io | bash \
   && chmod 755 /opt/bin/nextflow \
   && wget https://github.com/refresh-bio/KMC/releases/download/v3.0.0/KMC3.linux.tar.gz \
   && tar -zxvf KMC3.linux.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,12 @@ FROM ubuntu:latest
 MAINTAINER Dave Roe <droe@nmdp.org>
 
 # apt stuff
-RUN apt-get update && apt-get install -qyy curl git make vim cmake \
+RUN apt-get update \
+  && apt-get install -qyy curl git make vim cmake \
      gcc g++ unzip subversion gzip openjdk-8-jdk openjdk-8-doc groovy wget \
      zlib1g-dev gnuplot lynx maven \
 	 bzip2 libbz2-dev liblzma-dev libncurses5-dev libncursesw5-dev \
-  && apt-get clean \
+  && apt-get clean
 
 # install stuff
 RUN cd /opt && git clone https://github.com/droe-nmdp/kpi.git \

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,23 +9,22 @@ RUN apt-get update \
      bzip2 libbz2-dev liblzma-dev libncurses5-dev libncursesw5-dev \
   && apt-get clean
 
-# directory setup
-RUN mkdir -p /opt/kpi/input /opt/kpi/raw /opt/kpi/output /opt/kpi/src /opt/bin /opt/jars
-
 # install stuff
 RUN cd /opt \
   && git clone https://github.com/droe-nmdp/kpi.git \
+  && mkdir -p /opt/kpi/raw /opt/bin \
+  && cd /opt/bin \
   && wget http://www.nextflow.io/releases/v19.01.0/nextflow?a=install -o /opt/bin/nextflow \
   && chmod 755 /opt/bin/nextflow \
-  && cd /opt/bin \
   && wget https://github.com/refresh-bio/KMC/releases/download/v3.0.0/KMC3.linux.tar.gz \
   && tar -zxvf KMC3.linux.tar.gz \
   && rm -f KMC3.linux.tar.gz \
+  && mkdir -p /opt/jars
   && cd /opt/jars \
   && wget http://www.apache.org/dist/commons/math/binaries/commons-math3-3.6.1-bin.tar.gz \
   && tar -zxvf commons-math3-3.6.1-bin.tar.gz \
   && rm -f /opt/jars/commons-math3-3.6.1-bin.tar.gz
-
+  
 # google guava
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
 RUN cd /opt \
@@ -38,6 +37,7 @@ ENV NXF_OPTS "-Xms4G -Xmx20G"
 ENV LD_LIBRARY_PATH /opt/lib:$LD_LIBRARY_PATH
 
 # kpi source
+RUN mkdir -p /opt/kpi/input /opt/kpi/output /opt/kpi/src
 ENV PATH /opt/bin:/opt/kpi:/opt/kpi/src:/opt/bbmap:/opt/canu/Linux-amd64/bin:$PATH
 ENV CLASSPATH /opt/guava/guava/target/guava-HEAD-jre-SNAPSHOT.jar:/opt/jars/commons-math3-3.6.1/commons-math3-3.6.1.jar:$CLASSPATH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,25 @@
 FROM ubuntu:latest
 MAINTAINER Dave Roe <droe@nmdp.org>
 
-# install stuff
+# apt stuff
 RUN apt-get update && apt-get install -qyy curl git make vim cmake \
      gcc g++ unzip subversion gzip openjdk-8-jdk openjdk-8-doc groovy wget \
      zlib1g-dev gnuplot lynx maven \
 	 bzip2 libbz2-dev liblzma-dev libncurses5-dev libncursesw5-dev \
   && apt-get clean \
-  && cd /opt && git clone https://github.com/droe-nmdp/kpi.git \
+
+# install stuff
+RUN cd /opt && git clone https://github.com/droe-nmdp/kpi.git \
   && mkdir -p /opt/kpi/raw \
   && mkdir -p /opt/bin \
-  && cd /opt/bin && curl -fsSL get.nextflow.io | /bin/bash \
+  && wget http://www.nextflow.io/releases/v19.01.0/nextflow?a=install -o /opt/bin/nextflow \
   && cd /opt/bin && wget https://github.com/refresh-bio/KMC/releases/download/v3.0.0/KMC3.linux.tar.gz \
   && gunzip KMC3.linux.tar.gz && tar -xvf KMC3.linux.tar && rm -f KMC3.linux.tar \
-#  && cd /opt && wget https://sourceforge.net/projects/bbmap/files/latest/download \
-#  && mv download BBMap.tar && tar -xvzf BBMap.tar && rm BBMap.tar \
   && mkdir -p /opt/jars \
-#  && cd /opt && git clone https://github.com/marbl/canu.git && cd canu/src \
-#  && make -j 2 \
   && cd /opt/jars \
-  && wget http://mirrors.sorengard.com/apache//commons/math/binaries/commons-math3-3.6.1-bin.tar.gz \
+  && wget http://www.apache.org/dist/commons/math/binaries/commons-math3-3.6.1-bin.tar.gz \
   && gunzip commons-math3-3.6.1-bin.tar.gz && tar -xvf commons-math3-3.6.1-bin.tar \
-  && rm -f /opt/jars/commons-math3-3.6.1-bin.tar \
-#  && cd /opt/ && wget https://github.com/samtools/htslib/releases/download/1.8/htslib-1.8.tar.bz2 \
-#  && tar -xjvf htslib-1.8.tar.bz2 && cd htslib-1.8 && make && make install \
-#  && cd /opt/ && wget https://github.com/samtools/bcftools/releases/download/1.8/bcftools-1.8.tar.bz2 \
-#  && tar -xjvf bcftools-1.8.tar.bz2 && cd bcftools-1.8 && make && make install \
-#  && cd /opt/ && wget https://github.com/samtools/samtools/releases/download/1.8/samtools-1.8.tar.bz2 \
-#  && bunzip2 samtools-1.8.tar.bz2 \
-#  && tar -xvf samtools-1.8.tar && cd samtools-1.8 && make && make install \
-#  && rm -f /opt/*.bz2 /opt/*.tar* \
-  && apt-get clean
+  && rm -f /opt/jars/commons-math3-3.6.1-bin.tar
 
 # google guava
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN cd /opt \
   && wget https://github.com/refresh-bio/KMC/releases/download/v3.0.0/KMC3.linux.tar.gz \
   && tar -zxvf KMC3.linux.tar.gz \
   && rm -f KMC3.linux.tar.gz \
-  && mkdir -p /opt/jars
+  && mkdir -p /opt/jars \
   && cd /opt/jars \
   && wget http://www.apache.org/dist/commons/math/binaries/commons-math3-3.6.1-bin.tar.gz \
   && tar -zxvf commons-math3-3.6.1-bin.tar.gz \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,39 +6,39 @@ RUN apt-get update \
   && apt-get install -qyy curl git make vim cmake \
      gcc g++ unzip subversion gzip openjdk-8-jdk openjdk-8-doc groovy wget \
      zlib1g-dev gnuplot lynx maven \
-	 bzip2 libbz2-dev liblzma-dev libncurses5-dev libncursesw5-dev \
+     bzip2 libbz2-dev liblzma-dev libncurses5-dev libncursesw5-dev \
   && apt-get clean
 
+# directory setup
+RUN mkdir -p /opt/kpi/input /opt/kpi/raw /opt/kpi/output /opt/kpi/src /opt/bin /opt/jars
+
 # install stuff
-RUN cd /opt && git clone https://github.com/droe-nmdp/kpi.git \
-  && mkdir -p /opt/kpi/raw \
-  && mkdir -p /opt/bin \
+RUN cd /opt \
+  && git clone https://github.com/droe-nmdp/kpi.git \
   && wget http://www.nextflow.io/releases/v19.01.0/nextflow?a=install -o /opt/bin/nextflow \
-  && cd /opt/bin && wget https://github.com/refresh-bio/KMC/releases/download/v3.0.0/KMC3.linux.tar.gz \
-  && gunzip KMC3.linux.tar.gz && tar -xvf KMC3.linux.tar && rm -f KMC3.linux.tar \
-  && mkdir -p /opt/jars \
+  && chmod 755 /opt/bin/nextflow \
+  && cd /opt/bin \
+  && wget https://github.com/refresh-bio/KMC/releases/download/v3.0.0/KMC3.linux.tar.gz \
+  && tar -zxvf KMC3.linux.tar.gz \
+  && rm -f KMC3.linux.tar.gz \
   && cd /opt/jars \
   && wget http://www.apache.org/dist/commons/math/binaries/commons-math3-3.6.1-bin.tar.gz \
-  && gunzip commons-math3-3.6.1-bin.tar.gz && tar -xvf commons-math3-3.6.1-bin.tar \
-  && rm -f /opt/jars/commons-math3-3.6.1-bin.tar
+  && tar -zxvf commons-math3-3.6.1-bin.tar.gz \
+  && rm -f /opt/jars/commons-math3-3.6.1-bin.tar.gz
 
 # google guava
 ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
-RUN cd /opt && git clone https://github.com/google/guava.git \
-  && cd guava/guava/ && mvn install
+RUN cd /opt \
+  && git clone https://github.com/google/guava.git \
+  && cd guava/guava \
+  && mvn install
 
 # env vars
 ENV NXF_OPTS "-Xms4G -Xmx20G"
 ENV LD_LIBRARY_PATH /opt/lib:$LD_LIBRARY_PATH
 
 # kpi source
-RUN mkdir -p /opt/kpi/input /opt/kpi/output /opt/kpi/src
-ENV PATH /opt/bin:$PATH
-ENV PATH /opt/kpi:$PATH
-ENV PATH /opt/kpi/src:$PATH
-ENV PATH /opt/bbmap:$PATH
-ENV PATH /opt/canu/Linux-amd64/bin:$PATH
+ENV PATH /opt/bin:/opt/kpi:/opt/kpi/src:/opt/bbmap:/opt/canu/Linux-amd64/bin:$PATH
 ENV CLASSPATH /opt/guava/guava/target/guava-HEAD-jre-SNAPSHOT.jar:/opt/jars/commons-math3-3.6.1/commons-math3-3.6.1.jar:$CLASSPATH
 
-#CMD ["/bin/bash"]
 CMD ["/opt/kpi/main.nf"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,13 @@ RUN apt-get update \
   && apt-get clean
 
 # install stuff
+ENV TMPDIR /tmp
 RUN cd /opt \
   && git clone https://github.com/droe-nmdp/kpi.git \
   && mkdir -p /opt/kpi/raw /opt/bin \
   && cd /opt/bin \
   && wget -qO- http://get.nextflow.io | bash \
+  && sed -i s/"curl -fsSL"/"curl -fsSLk"/ /opt/bin/nextflow \
   && chmod 755 /opt/bin/nextflow \
   && /opt/bin/nextflow \
   && wget https://github.com/refresh-bio/KMC/releases/download/v3.0.0/KMC3.linux.tar.gz \


### PR DESCRIPTION
Greetings, 

I made some suggested changes to the Dockerfile to:
1. Update some dead download urls.
2. Change permissions on `/opt/bin/nextflow` to 755 so that it can run in an unprivileged environment from within a singularity container.
3. Run `nextflow` once so that its initial setup is performed and preserved in the container (again for singularity support).

(I also moved some things around to help me debug. I don't think any of that is important though.)